### PR TITLE
v1.1.2

### DIFF
--- a/info.txt
+++ b/info.txt
@@ -4,8 +4,8 @@
     "Author": "yukineko",
     "Description": "単位の日本語化やゲームを終了できない不具合を修正できるmodです",
     "ModVersion": 1,
-    "GameVersion": 2.04,
-    "Date": "08/09/2021",
+    "GameVersion": 2.048,
+    "Date": "06/07/2022",
     "Dependencies": [],
     "Disabled": 0,
     "AllowSteamAchievs":1

--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 var CookieTools = {
     name: 'CookieTools',
-    version: 'v1.1.1',
+    version: 'v1.1.2',
     config: {
         formatlang: 0
     },

--- a/main.js
+++ b/main.js
@@ -67,7 +67,7 @@ var CookieTools = {
             <div class="subsection" style="padding:0px;">
                 <div class="title">CookieTools</div>
                     <div class="listing">
-                    ${Game.WriteButton('format', 'formatButton', '短縮表記 OFF', '短縮表記 ON', 'BeautifyAll();Game.RefreshStore();Game.upgradesToRebuild=1;',1)}
+                    ${Game.WritePrefButton('format', 'formatButton', '短縮表記 OFF', '短縮表記 ON', 'BeautifyAll();Game.RefreshStore();Game.upgradesToRebuild=1;',1)}
                     <label>(巨大な数の表記を短縮します)</label><br>
                     
                     <a class="smallFancyButton option ${((this.config.formatlang > 0) ? '' : 'off')}" id="langButton" ${Game.clickStr}="CookieTools.langButton()">${this.config.formatlang > 0 ? '単位日本語化 形式' + this.config.formatlang : '単位日本語化 OFF'}</a>


### PR DESCRIPTION
ver2.048のアップデート以降、CookieToolsを導入した状態でオプションを開くとCookie Clickerがフリーズする不具合を修正。